### PR TITLE
feat(agreed-server): add middlewares option

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,16 @@ module.exports = (opts) => {
   const port = opts.port || 3000;
 
   app.use(bodyParser.json());
+
+  if (opts.middlewares) {
+    if (!Array.isArray(opts.middlewares)) {
+      throw new Error('[agreed-server] option.middlewares must be an array.');
+    }
+    opts.middlewares.forEach((fn) => {
+      app.use(fn);
+    });
+  }
+
   app.use(agreed.middleware(opts));
   app.use((err, req, res, next) => {
     res.statusCode = 500;
@@ -23,5 +33,4 @@ module.exports = (opts) => {
   });
   return app.listen(opts.port);
 };
-
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ const plzPort = require('plz-port');
 const agreedServer = require('../');
 const AssertStream = require('assert-stream');
 const http = require('http');
+const assert = require('assert');
 
 test('agreed-core: call server', () => {
   plzPort().then((port) => {
@@ -24,3 +25,26 @@ test('agreed-core: call server', () => {
     });
   });
 });
+
+test('pass middlewares option', () => {
+  plzPort().then((port) => {
+    const server = agreedServer({
+      path: './test/agreed',
+      port: port,
+      middlewares: [
+        (req, res, next) => {
+          res.set({"access-control-allow-origin": "*"});
+          next();
+        }
+      ]
+    });
+
+    server.on('listening', () => {
+      http.get(`http://localhost:${port}/users/yosuke`, (res) => {
+        server.close();
+        assert.deepEqual(res.headers["access-control-allow-origin"], "*");
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
This PR proposes (and Implements) `middlewares` options on `agreed-server`.

This option is useful for some common http headers (such as `Access-Control-Allow-Origin`).